### PR TITLE
always use host for appid

### DIFF
--- a/routers/user/auth.go
+++ b/routers/user/auth.go
@@ -209,14 +209,10 @@ func SignIn(ctx *context.Context) {
 	}
 
 	PubKeyEnc := base64.StdEncoding.EncodeToString(pubKey)
-	appId := ctx.Req.Request.Header.Get("X-Forwarded-For")
-	if appId == "" {
-		appId = ctx.Req.Request.Host
-	}
 
 	encoded := url.Values{}
 	encoded.Set("state", state)
-	encoded.Set("appid", strings.Split(appId, ",")[0])
+	encoded.Set("appid", ctx.Req.Request.Host)
 	encoded.Set("scope", `{"user": true, "email": true}`)
 	encoded.Set("redirecturl", "/user/callbackverify")
 	encoded.Set("publickey", PubKeyEnc)


### PR DESCRIPTION
Using X-Forwarded-For causes issues when an intermediate proxy server is used as it redirects from 3bot login to an ip different from the website.